### PR TITLE
add explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "doctrine/doctrine-bundle": "1.0.*",
         "doctrine/doctrine-fixtures-bundle": "dev-master",
         "liip/functional-test-bundle": "dev-master",
-        "liip/doctrine-cache-bundle": "dev-master"
+        "liip/doctrine-cache-bundle": "dev-master",
+        "sonata-project/doctrine-phpcr-admin-bundle": "dev-master"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
PHP Fatal error:  Class 'Sonata\AdminBundle\Controller\CRUDController' not found in /home/cordoval/sites-2/vendor/symfony-cmf/simple-cms-bundle/Symfony/Cmf/Bundle/SimpleCmsBundle/Controller/PageAdminController.php on line 8
