### PR TITLE
Update styling of error pages

### DIFF
--- a/app/Resources/TwigBundle/views/Exception/error.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error.html.twig
@@ -1,0 +1,14 @@
+{% extends "CmfMainBundle::layout.html.twig" %}
+
+{% block title %}An Error Occurred: {{ status_text }}{% endblock %}
+
+{% block content %}
+    <h2>Oops! An Error Occurred</h2>
+    <h3>The server returned a "{{ status_code }} {{ status_text }}".</h3>
+
+    <p>
+        Something is broken. Please e-mail us and let us know
+        what you were doing when this error occurred. We will fix it as soon
+        as possible. Sorry for any inconvenience caused.
+    </p>
+{% endblock %}


### PR DESCRIPTION
I fixed this issue: https://github.com/symfony-cmf/symfony-cmf-website/issues/23. Any feedback is welcome, would be nice if this could be merged. 
